### PR TITLE
Update setuptools to 65.5.1

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -10,3 +10,5 @@ PyJWT[crypto]==2.4.0
 six==1.16.0
 sqlparse==0.4.4
 uwsgi==2.0.21
+
+setuptools>=65.5.1 # CVE-2022-40897


### PR DESCRIPTION
previous versions are vulnerable: CVE-2022-40897