### PR TITLE
Add support for CORS headers

### DIFF
--- a/apikeyclient/Makefile
+++ b/apikeyclient/Makefile
@@ -1,8 +1,9 @@
-.PHONY: clean
+.DEFAULT_GOAL := build
+
+.PHONY: clean build
 clean:
 	find . -type d -name __pycache__ -exec rm -r {} \+
 	rm -rf build dist
 
-.PHONY: build
 build: clean
 	python -m build --sdist --wheel .

--- a/server/apikeyserv/settings.py
+++ b/server/apikeyserv/settings.py
@@ -51,12 +51,14 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    "corsheaders",
     "apikeys.apps.ApikeysConfig",
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    "corsheaders.middleware.CorsMiddleware",
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -151,3 +153,8 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # To run on a subpath, we need to define this variable.
 FORCE_SCRIPT_NAME = env.get('FORCE_SCRIPT_NAME')
+
+
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"^https://(\w|\.)+\.amsterdam\.nl$",
+]

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,7 @@
 asgiref==3.6.0
 cffi==1.15.0
 Django==4.2.3
+django-cors-headers==4.2.0
 django-healthchecks==1.5.0
 psycopg2-binary==2.9.6
 pycparser==2.21


### PR DESCRIPTION
The API will be used from another amsterdam.nl subdomain. So we need CORS headers to make this possible from a frontend application in the browser.