### PR TITLE
Because we are not using DRF, explicit support for OPTIONS call

### DIFF
--- a/server/apikeys/views.py
+++ b/server/apikeys/views.py
@@ -38,6 +38,8 @@ def index(request):
 @csrf_exempt
 def api_keys(request):
     """API endpoint for requesting new api keys."""
+    if request.method == "OPTIONS":
+        return HttpResponse(status=204)
     if request.method == "GET":
         # We do not want to expose the keys
         raise PermissionDenied()


### PR DESCRIPTION
For cors, preflights will be done by browser doing OPTIONS calls. We need to support those calls. The middelware will enhance the response with the necessary headers.