### PR TITLE
AB#91069 Add an additional path for the registration form.

### DIFF
--- a/server/apikeys/urls.py
+++ b/server/apikeys/urls.py
@@ -1,10 +1,12 @@
+from django.contrib.admin.options import RedirectView
 from django.urls import path
 
 from . import views
 
 
 urlpatterns = [
-    path("", views.request_new_key),
+    path("", RedirectView.as_view(url="register", permanent=False)),
+    path("register/", views.request_new_key),
     path("signingkeys/", views.index, name="index"),
     path("apikeys/", views.api_keys),
 ]


### PR DESCRIPTION
For now, we redirect the root to this path.
The root can provided with a static page with an explanation about the api keys later on.