### PR TITLE
AB#92103 Add possibility to use api key in query string

### DIFF
--- a/apikeyclient/tests/test_logging.py
+++ b/apikeyclient/tests/test_logging.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 from django.test import override_settings
 import apikeyclient
@@ -14,15 +14,15 @@ API_KEY = (
 # Duck typing a request.
 @dataclass
 class DummyRequest:
-    headers: dict
+    headers: dict = field(default_factory=dict)
+    GET: dict = field(default_factory=dict)
 
 
 def get_response(_request):
     _request
-    pass
 
 
-def test_logging_of_api_keys(caplog, monkeypatch):
+def test_logging_of_api_keys(caplog):
     """Prove that the API key is logged when a logger is configured.
 
     In the conftest an API_KEY_LOGGER is configured, so the API KEY needs
@@ -33,6 +33,20 @@ def test_logging_of_api_keys(caplog, monkeypatch):
         middleware = apikeyclient.ApiKeyMiddleware(get_response)
         with caplog.at_level(logging.INFO):
             middleware(DummyRequest(headers={"X-Api-Key": API_KEY}))
+            assert caplog.records[0].getMessage() == f"API KEY: '{API_KEY}'"
+
+
+def test_logging_of_api_keys_in_query_string(caplog):
+    """Prove that the API key is logged when a logger is configured.
+
+    In the conftest an API_KEY_LOGGER is configured, so the API KEY needs
+    to show up in the logs.
+    """
+
+    with override_settings(APIKEY_LOGGER="api-key-logger"):
+        middleware = apikeyclient.ApiKeyMiddleware(get_response)
+        with caplog.at_level(logging.INFO):
+            middleware(DummyRequest(GET={"x-api-key": API_KEY}))
             assert caplog.records[0].getMessage() == f"API KEY: '{API_KEY}'"
 
 


### PR DESCRIPTION
For some clients of WFS and MVT api's it can be hard or even impossible to use api keys using http headers.

It is now also possible to pass in the api key as a querystring with the name `x-api-key`. The same JWT token can be used. The JWT tokens are url-safe. A possible caveat could be that the url gets too long, however most browsers/tools are supporting fairly largs urls (about 2K chars).

The api key middleware now also does a (deliberately) simple user agent check on incoming requests. Otherwise the API frontpage + docs are not accessible without an API key.