### PR TITLE
AB#91451 Handle situation that apikeyserver is down

### DIFF
--- a/apikeyclient/README.md
+++ b/apikeyclient/README.md
@@ -28,9 +28,9 @@ Install the middelware in the settings.py of your Django settings with:
 
 And add the following constants to you Django settings:
 
-    - APIKEY_MANDATORY: an api key is mandatory in incoming requests
     - APIKEY_ENDPOINT: The url of the apikeyserver where the sigingkeys
       are collected (path in the url is `/signingkeys/`)
+    - APIKEY_MANDATORY: an api key is mandatory in incoming requests
 
 
 If for some reason the middelware cannot be configured to access


### PR DESCRIPTION
If keys are mandatory, we must have the apikeyserver running, because we need to be able to fetch the signing keys for checking the incoming api keys.

If api keys are not mandatory, we do not bail out, however if no signing keys are available, we cannot do any checks. So, we add an extra warning on every api key check to make it as clear as possible in the logs,
that no checking can be done.