### PR TITLE
AB#91451 Do not bail out if connection fails from thread

### DIFF
--- a/apikeyclient/src/apikeyclient/__init__.py
+++ b/apikeyclient/src/apikeyclient/__init__.py
@@ -111,7 +111,7 @@ class Client:
         self._interval = KEY_FETCH_INTERVAL
         self._url = url
 
-        self._keys = self._fetch_keys()
+        self._keys = self._fetch_keys(bailoutIfNoConnection=True)
 
         # If no keys can be fetched we keep checking with a shorter _interval
         # until keys are found.
@@ -130,7 +130,7 @@ class Client:
             logger.warning("No signing keys available!")
         return check_token(token, keys)
 
-    def _fetch_keys(self):
+    def _fetch_keys(self, bailoutIfNoConnection=False):
         try:
             # Add timeout too avoid blocking this thread for too long.
             resp = requests.get(self._url, timeout=5)
@@ -142,7 +142,7 @@ class Client:
             logger.error("could not fetch JWKS from %s: %s", self._url, e)
             # If keys are mandatory, but no signing keys can be fetched,
             # we should not be able to continue.
-            if bool(settings.APIKEY_MANDATORY):
+            if bool(settings.APIKEY_MANDATORY) and bailoutIfNoConnection:
                 logger.error(
                     "Because settings.APIKEY_MANDATORY is True, "
                     "and we cannot connect to the API Key server, we bail out here!"


### PR DESCRIPTION
When the api key middleware is initialized and the keys are mandatory, an exception is raised if there is no connection to the api key server.

However, when the dso api is already running, and the api key server is going down, the keys are already connected, so dso can keep running.

When the middleware tries to refresh the keys in this situation, and this is not possible, because the key server is down, an exception should *not* be raised, because this would silently kill the thread and no signing key refreshing is possible anymore, until the DSO gets restarted.

Maybe this situation is a bit hypothetical, because we run DSO with uwsgi and UWSGI_HARAKIRI has been set to a relatively short period of 1800 seconds. But, better safe than sorry.