### PR TITLE
Change global `variables` to `vars`

### DIFF
--- a/.github/workflows/trigger-ado-deploy.yml
+++ b/.github/workflows/trigger-ado-deploy.yml
@@ -14,6 +14,6 @@ jobs:
         - name: Call Azure
           uses: Azure/pipelines@v1
           with:
-            azure-devops-project-url: ${{ variables.AZURE_DEVOPS_URL }}
-            azure-pipeline-name: ${{ variables.AZURE_DEVOPS_PIPELINE }}
+            azure-devops-project-url: ${{ vars.AZURE_DEVOPS_URL }}
+            azure-pipeline-name: ${{ vars.AZURE_DEVOPS_PIPELINE }}
             azure-devops-token: ${{ secrets.AZURE_DEVOPS_TOKEN }}


### PR DESCRIPTION
The global name holding the variables defines in github seems to be `vars` and not `variables`.