### PR TITLE
Do not use extension in url paths

### DIFF
--- a/server/apikeys/urls.py
+++ b/server/apikeys/urls.py
@@ -9,5 +9,5 @@ urlpatterns = [
     path("register/", views.request_new_key),
     path("signingkeys/", views.index, name="index"),
     path("apikeys/", views.api_keys),
-    path("docs.html", views.documentation),
+    path("docs/", views.documentation),
 ]


### PR DESCRIPTION
Seems that the rewrite for nginx ingress on AKS does not like that.