### PR TITLE
Let Django create the absolute urls.

### DIFF
--- a/server/apikeys/templates/apikeys/docs.html
+++ b/server/apikeys/templates/apikeys/docs.html
@@ -11,7 +11,7 @@
 
         <p>
            To use the api keys for gemeente amsterdam APIs, the
-            first step is to obtain a key using the online <a href="./register">form</a>.
+                first step is to obtain a key using the online <a href="{{ form_url }}">form</a>.
 
         </p>
         <p>

--- a/server/apikeys/templates/apikeys/form.html
+++ b/server/apikeys/templates/apikeys/form.html
@@ -26,7 +26,7 @@
 
         <p>
             Technische documentatie over het gebruik van de API Keys
-                is <a href="../docs.html">hier</a> te vinden.
+                is <a href="{{ docs_url }}">hier</a> te vinden.
         </p>
 
         <form action="{{ request.path }}" method="post">

--- a/server/apikeys/views.py
+++ b/server/apikeys/views.py
@@ -101,9 +101,10 @@ def request_new_key(request):
     else:
         form = RequestForm()
 
-    return render(request, "apikeys/form.html", {"form": form})
-
+    docs_url = request.build_absolute_uri("/docs/")
+    return render(request, "apikeys/form.html", {"form": form, "docs_url": docs_url})
 
 
 def documentation(request):
-    return render(request, "apikeys/docs.html", {})
+    form_url = request.build_absolute_uri("/register/")
+    return render(request, "apikeys/docs.html", {"form_url": form_url})


### PR DESCRIPTION
Hopefully, this will work for the rewritten urls by the ingress controller. If ingress contr. provides `SCRIPT_NAME`, and Django uses this, it will work.

Otherwise, we need to define `FORCE_SCRIPT_NAME` in Django settings and fetch the value for this from an env. var.