### PR TITLE
AB#98739 Strip x-api-key query parm from request

### DIFF
--- a/apikeyclient/src/apikeyclient/__init__.py
+++ b/apikeyclient/src/apikeyclient/__init__.py
@@ -50,7 +50,14 @@ class ApiKeyMiddleware:
         if request.headers.get("User-Agent", "").startswith("Mozilla"):
             return self._get_response(request)
 
-        token = request.headers.get("X-Api-Key", request.GET.get("x-api-key"))
+        token = request.headers.get("X-Api-Key")
+        if token is None:
+            token = request.GET.get("x-api-key")
+            if token:
+                # Make a copy of request.GET, to mutate it
+                request.GET = request.GET.copy()
+                # we need to get rid of the query param, DSO API does not recognize it
+                del request.GET['x-api-key']
         if token is None and self._mandatory:
             return JsonResponse({"message": "API key missing"}, status=HTTPStatus.UNAUTHORIZED)
         if token is not None:

--- a/client/__init__.py
+++ b/client/__init__.py
@@ -35,7 +35,7 @@ def index(_request):
     return HttpResponse('{"status": "ok"}', content_type="application/json")
 
 
-urlpatterns = (re_path(r"^$", index),)
+urlpatterns = (re_path(r"^$", index), re_path(r"^v1/wfs$", index))
 
 application = get_wsgi_application()
 


### PR DESCRIPTION
Because when it is passed on to the DSO API, this does not recognize this a DSO search param, so it errors.