### PR TITLE
134810: Missing libexpat library

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,6 +13,9 @@ RUN useradd -M -U datapunt
 
 RUN apt -y update && apt -y upgrade
 
+# Install libexpat1 for uwsgi
+RUN apt -y install libexpat1
+
 # Copy python build artifacts from builder image
 COPY --from=builder /usr/local/bin/ /usr/local/bin/
 COPY --from=builder /usr/local/lib/python3.12/site-packages/ /usr/local/lib/python3.12/site-packages/


### PR DESCRIPTION
Installing the libexpat in the Dockerfile solved it for me, now we should check the pipeline. 