### PR TITLE
Do not validate token expiration

### DIFF
--- a/apikeyclient/src/apikeyclient/__init__.py
+++ b/apikeyclient/src/apikeyclient/__init__.py
@@ -103,7 +103,7 @@ def check_token(token, keys):
     """Checks a token against list of signing keys."""
     for key in keys:
         try:
-            dec = jwt.decode(token, key, algorithms="EdDSA")
+            dec = jwt.decode(token, key, algorithms="EdDSA", options={'verify_exp': False})
             return dec["sub"]
         except (jwt.InvalidSignatureError, jwt.DecodeError, jwt.ExpiredSignatureError):
             continue


### PR DESCRIPTION
Do not throw an error when a token is expired. We need to set up processes for renewal first.