### PR TITLE
upgrade pip

### DIFF
--- a/server/requirements_dev.txt
+++ b/server/requirements_dev.txt
@@ -111,7 +111,7 @@ wheel==0.46.2
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0
+pip==26.1
     # via pip-tools
 setuptools==82.0.1
     # via


### PR DESCRIPTION
Lost security issue op.
Werd niet opgepakt door dependabot, pip-tools had de dependency op pip nog niet scherp gezet. 